### PR TITLE
Fix NullPointerException when link field is missing from addressbook.json

### DIFF
--- a/src/main/java/educonnect/commons/util/CollectionUtil.java
+++ b/src/main/java/educonnect/commons/util/CollectionUtil.java
@@ -32,4 +32,11 @@ public class CollectionUtil {
     public static boolean isAnyNonNull(Object... items) {
         return items != null && Arrays.stream(items).anyMatch(Objects::nonNull);
     }
+
+    /**
+     * Returns the count of {@code items} that are non-null.
+     */
+    public static int countNonNull(Object... items) {
+        return (int) Stream.of(items).filter(Objects::nonNull).count();
+    }
 }

--- a/src/main/java/educonnect/logic/Messages.java
+++ b/src/main/java/educonnect/logic/Messages.java
@@ -45,7 +45,7 @@ public class Messages {
                 .append(";\nTelegram Handle: ")
                 .append(student.getTelegramHandle())
                 .append(";\nLink: ")
-                .append(student.getLink())
+                .append(student.getLink().map(link -> link.url).orElse(""))
                 .append(";\nTags: ");
         student.getTags().forEach(builder::append);
         builder.append(";\n").append(student.getTimetable());

--- a/src/main/java/educonnect/logic/commands/EditCommand.java
+++ b/src/main/java/educonnect/logic/commands/EditCommand.java
@@ -116,7 +116,7 @@ public class EditCommand extends Command {
         Email updatedEmail = editStudentDescriptor.getEmail().orElse(studentToEdit.getEmail());
         TelegramHandle updatedTelegramHandle = editStudentDescriptor.getTelegramHandle().orElse(
                     studentToEdit.getTelegramHandle());
-        Link updatedLink = editStudentDescriptor.getLink().orElse(studentToEdit.getLink());
+        Optional<Link> updatedLink = editStudentDescriptor.getLink().or(() -> studentToEdit.getLink());
         Set<Tag> updatedTags = editStudentDescriptor.getTags().orElse(studentToEdit.getTags());
         Timetable timetable = editStudentDescriptor.getTimetable().orElse(studentToEdit.getTimetable());
 

--- a/src/main/java/educonnect/logic/parser/AddCommandParser.java
+++ b/src/main/java/educonnect/logic/parser/AddCommandParser.java
@@ -43,7 +43,7 @@ public class AddCommandParser implements Parser<AddCommand> {
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_STUDENT_ID, PREFIX_EMAIL,
-                         PREFIX_TELEGRAM_HANDLE, PREFIX_TAG, PREFIX_TIMETABLE);
+                        PREFIX_TELEGRAM_HANDLE, PREFIX_TAG, PREFIX_TIMETABLE);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_STUDENT_ID, PREFIX_TELEGRAM_HANDLE, PREFIX_EMAIL)
                 || !argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/educonnect/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/educonnect/logic/parser/ArgumentMultimap.java
@@ -75,4 +75,8 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
+
+    public boolean areAnyPrefixesPresent(Prefix... prefixes) {
+        return Stream.of(prefixes).anyMatch(prefix -> argMultimap.containsKey(prefix));
+    }
 }

--- a/src/main/java/educonnect/logic/parser/LinkCommandParser.java
+++ b/src/main/java/educonnect/logic/parser/LinkCommandParser.java
@@ -7,9 +7,8 @@ import static educonnect.logic.parser.CliSyntax.PREFIX_NAME;
 import static educonnect.logic.parser.CliSyntax.PREFIX_STUDENT_ID;
 import static educonnect.logic.parser.CliSyntax.PREFIX_TAG;
 import static educonnect.logic.parser.CliSyntax.PREFIX_TELEGRAM_HANDLE;
+import static educonnect.logic.parser.CliSyntax.PREFIX_TIMETABLE;
 import static java.util.Objects.requireNonNull;
-
-import java.util.stream.Stream;
 
 import educonnect.logic.commands.LinkCommand;
 import educonnect.logic.parser.exceptions.ParseException;
@@ -28,75 +27,62 @@ public class LinkCommandParser implements Parser<LinkCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_STUDENT_ID,
-                        PREFIX_EMAIL, PREFIX_TELEGRAM_HANDLE, PREFIX_TAG, PREFIX_LINK);
+                        PREFIX_EMAIL, PREFIX_TELEGRAM_HANDLE, PREFIX_TAG, PREFIX_LINK, PREFIX_TIMETABLE);
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_STUDENT_ID, PREFIX_EMAIL, PREFIX_TELEGRAM_HANDLE,
                 PREFIX_LINK);
 
         // No prefixes used
-        if (!areAnyPrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_TAG, PREFIX_STUDENT_ID, PREFIX_EMAIL,
+        if (!argMultimap.areAnyPrefixesPresent(PREFIX_NAME, PREFIX_TAG, PREFIX_STUDENT_ID, PREFIX_EMAIL,
                 PREFIX_TELEGRAM_HANDLE, PREFIX_TAG, PREFIX_LINK)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     LinkCommand.MESSAGE_USAGE));
         }
 
-        // No link provided
-        if (!arePrefixesPresent(argMultimap, PREFIX_LINK)) {
+        // Non-unique identifiers present
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()
+                || argMultimap.getValue(PREFIX_TAG).isPresent()
+                || argMultimap.getValue(PREFIX_TIMETABLE).isPresent()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    LinkCommand.NON_UNIQUE_IDENTIFIER_MESSAGE));
+        }
+
+        LinkCommand.LinkStudentDescriptor linkStudentDescriptor = new LinkCommand.LinkStudentDescriptor();
+
+        // Parse unique identifiers
+        if (argMultimap.getValue(PREFIX_STUDENT_ID).isPresent()) {
+            linkStudentDescriptor.setStudentId(
+                    ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_STUDENT_ID).get()));
+        }
+        if (argMultimap.getValue(PREFIX_TELEGRAM_HANDLE).isPresent()) {
+            linkStudentDescriptor.setTelegramHandle(
+                    ParserUtil.parseTelegramHandle(argMultimap.getValue(PREFIX_TELEGRAM_HANDLE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            linkStudentDescriptor.setEmail(ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
+        }
+        // Multiple unique identifiers present
+        if (linkStudentDescriptor.countUniqueIdentifiers() > 1) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    LinkCommand.MULTIPLE_UNIQUE_IDENTIFIER_MESSAGE));
+        }
+        // No unique identifiers present
+        if (linkStudentDescriptor.countUniqueIdentifiers() == 0) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    LinkCommand.NO_UNIQUE_IDENTIFIER_MESSAGE));
+        }
+
+        if (argMultimap.getValue(PREFIX_LINK).isPresent()) {
+            String link = argMultimap.getValue(PREFIX_LINK).get();
+            if (!link.isBlank()) {
+                linkStudentDescriptor.setLink(ParserUtil.parseLink(link));
+            }
+        } else {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     LinkCommand.NO_LINK_IDENTIFIER_MESSAGE));
         }
 
-        // Non-unique identifiers present
-        if (areAnyPrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_TAG)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    LinkCommand.NO_UNIQUE_IDENTIFIER_MESSAGE));
-        }
-
-        // Multiple unique identifiers present
-        if (arePrefixesPresent(argMultimap, PREFIX_STUDENT_ID, PREFIX_TELEGRAM_HANDLE, PREFIX_EMAIL)
-                || arePrefixesPresent(argMultimap, PREFIX_TELEGRAM_HANDLE, PREFIX_EMAIL)
-                || arePrefixesPresent(argMultimap, PREFIX_STUDENT_ID, PREFIX_EMAIL)
-                || arePrefixesPresent(argMultimap, PREFIX_STUDENT_ID, PREFIX_TELEGRAM_HANDLE)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    LinkCommand.MULTIPLE_UNIQUE_IDENTIFIER_MESSAGE));
-        }
-
-        LinkCommand.LinkStudentDescriptor editPersonDescriptor = new LinkCommand.LinkStudentDescriptor();
-
-
-        // Find the unique identifier used only one of the guard clause will be triggered
-        if (argMultimap.getValue(PREFIX_STUDENT_ID).isPresent()) {
-            editPersonDescriptor.setStudentId(
-                    ParserUtil.parseStudentId(argMultimap.getValue(PREFIX_STUDENT_ID).get()));
-        }
-        if (argMultimap.getValue(PREFIX_TELEGRAM_HANDLE).isPresent()) {
-            editPersonDescriptor.setTelegramHandle(
-                    ParserUtil.parseTelegramHandle(argMultimap.getValue(PREFIX_TELEGRAM_HANDLE).get()));
-        }
-        if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
-            editPersonDescriptor.setEmail(
-                    ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get()));
-        }
-        if (argMultimap.getValue(PREFIX_LINK).isPresent()) {
-            editPersonDescriptor.setLink(ParserUtil.parseLink(argMultimap.getValue(PREFIX_LINK).get()));
-        }
-
-        if (areAnyPrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_TAG)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    LinkCommand.NO_UNIQUE_IDENTIFIER_MESSAGE));
-        }
-
-        return new LinkCommand(editPersonDescriptor);
+        return new LinkCommand(linkStudentDescriptor);
 
     }
-    private static boolean areAnyPrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).anyMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
-
-
-
 }

--- a/src/main/java/educonnect/model/student/Link.java
+++ b/src/main/java/educonnect/model/student/Link.java
@@ -26,7 +26,22 @@ public class Link {
         return test.matches(VALIDATION_REGEX);
     }
 
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
 
+        // instanceof handles nulls
+        if (!(other instanceof Link)) {
+            return false;
+        }
+
+        Link otherLink = (Link) other;
+        return url.equals(otherLink.url);
+    }
+
+    @Override
     public String toString() {
         return url;
     }

--- a/src/main/java/educonnect/model/student/Student.java
+++ b/src/main/java/educonnect/model/student/Student.java
@@ -5,6 +5,7 @@ import static educonnect.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import educonnect.commons.util.ToStringBuilder;
@@ -21,7 +22,7 @@ public class Student {
     private final StudentId studentId;
     private final TelegramHandle telegramHandle;
     private final Email email;
-    private final Link link;
+    private final Optional<Link> link;
 
     // Data fields
     private final Set<Tag> tags = new HashSet<>();
@@ -38,7 +39,7 @@ public class Student {
         this.studentId = studentId;
         this.email = email;
         this.telegramHandle = telegramHandle;
-        this.link = new Link("");
+        this.link = Optional.empty();
         this.tags.addAll(tags);
         this.timetable = timetable;
     }
@@ -47,7 +48,7 @@ public class Student {
      * Constructs an {@code Student}.
      * Every field must be present and not null.
      */
-    public Student(Name name, StudentId studentId, Email email, TelegramHandle telegramHandle, Link link,
+    public Student(Name name, StudentId studentId, Email email, TelegramHandle telegramHandle, Optional<Link> link,
                    Set<Tag> tags, Timetable timetable) {
         requireAllNonNull(name, studentId, email, telegramHandle, tags);
         this.name = name;
@@ -75,8 +76,10 @@ public class Student {
         return telegramHandle;
     }
 
-    public Link getLink() {
-        return link; }
+    public Optional<Link> getLink() {
+        return link;
+    }
+
     /**
      * Returns an immutable tag set, which throws {@code UnsupportedOperationException}
      * if modification is attempted.
@@ -198,13 +201,14 @@ public class Student {
                 && studentId.equals(otherStudent.studentId)
                 && email.equals(otherStudent.email)
                 && telegramHandle.equals(otherStudent.telegramHandle)
-                && tags.equals(otherStudent.tags);
+                && tags.equals(otherStudent.tags)
+                && link.equals(otherStudent.link);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, studentId, email, telegramHandle, tags);
+        return Objects.hash(name, studentId, email, telegramHandle, tags, link);
     }
 
     @Override

--- a/src/main/java/educonnect/model/student/timetable/Timetable.java
+++ b/src/main/java/educonnect/model/student/timetable/Timetable.java
@@ -110,6 +110,7 @@ public class Timetable {
 
         return sb.toString();
     }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/educonnect/storage/JsonAdaptedStudent.java
+++ b/src/main/java/educonnect/storage/JsonAdaptedStudent.java
@@ -109,7 +109,10 @@ class JsonAdaptedStudent {
         }
         final Email modelEmail = new Email(email);
 
-
+        if (link == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                Link.class.getSimpleName()));
+        }
         if (!Link.isValidLink(link)) {
             throw new IllegalValueException(Link.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/educonnect/storage/JsonAdaptedStudent.java
+++ b/src/main/java/educonnect/storage/JsonAdaptedStudent.java
@@ -3,6 +3,7 @@ package educonnect.storage;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -65,7 +66,7 @@ class JsonAdaptedStudent {
         studentId = source.getStudentId().value;
         email = source.getEmail().value;
         telegramHandle = source.getTelegramHandle().value;
-        link = source.getLink().url;
+        link = source.getLink().map(link -> link.url).orElse(null);
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -109,14 +110,15 @@ class JsonAdaptedStudent {
         }
         final Email modelEmail = new Email(email);
 
+        final Optional<Link> modelLink;
         if (link == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                Link.class.getSimpleName()));
+            modelLink = Optional.empty();
+        } else {
+            if (!Link.isValidLink(link)) {
+                throw new IllegalValueException(Link.MESSAGE_CONSTRAINTS);
+            }
+            modelLink = Optional.of(new Link(link));
         }
-        if (!Link.isValidLink(link)) {
-            throw new IllegalValueException(Link.MESSAGE_CONSTRAINTS);
-        }
-        final Link modelLink = new Link(link);
 
         if (telegramHandle == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,

--- a/src/main/java/educonnect/ui/StudentCard.java
+++ b/src/main/java/educonnect/ui/StudentCard.java
@@ -65,9 +65,7 @@ public class StudentCard extends UiPart<Region> {
         telegram.setText(student.getTelegramHandle().value);
         hyperlink.setText("Project Link");
         // Set the visibility of the hyperlink based on whether the student has a non-empty URL
-        String url = student.getLink().url; // Assuming getLink().url returns a String
-        boolean isUrlPresent = url != null && !url.isEmpty();
-        hyperlink.setVisible(isUrlPresent);
+        hyperlink.setVisible(student.getLink().isPresent());
 
         student.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
@@ -77,11 +75,8 @@ public class StudentCard extends UiPart<Region> {
 
     @FXML
     void openLink(ActionEvent action) throws URISyntaxException, IOException {
-        String url = student.getLink().toString();
-        if (url != null || !url.isEmpty()) {
-
-            Desktop.getDesktop().browse(new URI(url));
-
+        if (student.getLink().isPresent()) {
+            Desktop.getDesktop().browse(new URI(student.getLink().get().url));
         } else {
             System.out.println("No Link has been added yet");
         }

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.stage.Stage?>
 
 <?import javafx.scene.layout.HBox?>
-<fx:root onCloseRequest="#handleExit" title="EduConnect" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root onCloseRequest="#handleExit" title="EduConnect" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>

--- a/src/main/resources/view/StudentListCard.fxml
+++ b/src/main/resources/view/StudentListCard.fxml
@@ -11,7 +11,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />

--- a/src/test/data/JsonSerializableAddressBookTest/typicalStudentsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalStudentsAddressBook.json
@@ -41,7 +41,7 @@
       } ],
       "numOfDays" : 5
     },
-    "link": "https://github.com/tanjiajiajun/tp"
+    "link": "https://en.wikipedia.org/wiki/LeBron_James"
   }, {
     "name" : "Benson Meier",
     "studentId" : "A1235678J",
@@ -67,7 +67,7 @@
       } ],
       "numOfDays" : 5
     },
-    "link": "https://github.com/tanjiajiajun/tp"
+    "link": "https://www.google.com/"
   }, {
     "name" : "Carl Kurz",
     "studentId" : "A9876543N",
@@ -135,7 +135,7 @@
       } ],
       "numOfDays" : 5
     },
-    "link": "https://github.com/tanjiajiajun/tp"
+    "link": "https://en.wikipedia.org/wiki/LeBron_James"
   }, {
     "name" : "Elle Meyer",
     "studentId" : "A9482224Y",
@@ -203,7 +203,7 @@
       } ],
       "numOfDays" : 5
     },
-    "link": "https://github.com/tanjiajiajun/tp"
+    "link": "https://en.wikipedia.org/wiki/LeBron_James"
   }, {
     "name" : "George Best",
     "studentId" : "A6482442L",
@@ -245,6 +245,6 @@
       } ],
       "numOfDays" : 5
     },
-    "link": "https://github.com/tanjiajiajun/tp"
+    "link": null
   } ]
 }

--- a/src/test/java/educonnect/logic/LogicManagerTest.java
+++ b/src/test/java/educonnect/logic/LogicManagerTest.java
@@ -168,7 +168,7 @@ public class LogicManagerTest {
         // Triggers the saveAddressBook method by executing an add command
         String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + STUDENT_ID_DESC_AMY
                 + EMAIL_DESC_AMY + TELEGRAM_HANDLE_DESC_AMY;
-        Student expectedStudent = new StudentBuilder(AMY).withTags().build();
+        Student expectedStudent = new StudentBuilder(AMY).withTags().buildNoLink();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addStudent(expectedStudent);
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);

--- a/src/test/java/educonnect/logic/commands/CommandTestUtil.java
+++ b/src/test/java/educonnect/logic/commands/CommandTestUtil.java
@@ -1,6 +1,7 @@
 package educonnect.logic.commands;
 
 import static educonnect.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static educonnect.logic.parser.CliSyntax.PREFIX_LINK;
 import static educonnect.logic.parser.CliSyntax.PREFIX_NAME;
 import static educonnect.logic.parser.CliSyntax.PREFIX_STUDENT_ID;
 import static educonnect.logic.parser.CliSyntax.PREFIX_TAG;
@@ -40,7 +41,8 @@ public class CommandTestUtil {
     public static final String VALID_TELEGRAM_HANDLE_AMY = "@amyb";
     public static final String VALID_TELEGRAM_HANDLE_BOB = "@choobobco";
     public static final String VALID_TELEGRAM_HANDLE_JOHN = "@doedoejohnjohn.joe";
-
+    public static final String VALID_LINK_AMY = "https://www.youtube.com/";
+    public static final String VALID_LINK_BOB = "https://https://en.wikipedia.org/wiki/Code/";
     public static final String VALID_LINK_JOHN = "https://www.google.com/";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
@@ -54,11 +56,12 @@ public class CommandTestUtil {
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
     public static final String TELEGRAM_HANDLE_DESC_AMY = " " + PREFIX_TELEGRAM_HANDLE + VALID_TELEGRAM_HANDLE_AMY;
     public static final String TELEGRAM_HANDLE_DESC_BOB = " " + PREFIX_TELEGRAM_HANDLE + VALID_TELEGRAM_HANDLE_BOB;
+    public static final String LINK_DESC_AMY = " " + PREFIX_LINK + VALID_LINK_AMY;
+    public static final String LINK_DESC_BOB = " " + PREFIX_LINK + VALID_LINK_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
     public static final String TIMETABLE_DESC_VALID1 = " " + PREFIX_TIMETABLE + VALID_TIMETABLE_1;
     public static final String TIMETABLE_DESC_VALID2 = " " + PREFIX_TIMETABLE + VALID_TIMETABLE_2;
-
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_STUDENT_ID_DESC =
@@ -86,14 +89,17 @@ public class CommandTestUtil {
         DESC_AMY = new EditStudentDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withStudentId(VALID_STUDENT_ID_AMY).withEmail(VALID_EMAIL_AMY)
                 .withTelegramHandle(VALID_TELEGRAM_HANDLE_AMY)
+                .withLink(VALID_LINK_AMY)
                 .withTags(VALID_TAG_FRIEND).build();
         DESC_BOB = new EditStudentDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withStudentId(VALID_STUDENT_ID_BOB).withEmail(VALID_EMAIL_BOB)
                 .withTelegramHandle(VALID_TELEGRAM_HANDLE_BOB)
+                .withLink(VALID_LINK_BOB)
                 .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
         DESC_JOHN = new EditStudentDescriptorBuilder().withName(VALID_NAME_JOHN)
                 .withStudentId(VALID_STUDENT_ID_JOHN).withEmail(VALID_EMAIL_JOHN)
                 .withTelegramHandle(VALID_TELEGRAM_HANDLE_JOHN)
+                .withLink(VALID_LINK_JOHN)
                 .withTags(VALID_TAG_SMART).build();
     }
 

--- a/src/test/java/educonnect/logic/commands/EditCommandTest.java
+++ b/src/test/java/educonnect/logic/commands/EditCommandTest.java
@@ -38,7 +38,7 @@ public class EditCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Student editedStudent = new StudentBuilder().buildNoLink();
+        Student editedStudent = new StudentBuilder().build();
         EditStudentDescriptor descriptor = new EditStudentDescriptorBuilder(editedStudent).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_STUDENT, descriptor);
 

--- a/src/test/java/educonnect/logic/commands/LinkCommandTest.java
+++ b/src/test/java/educonnect/logic/commands/LinkCommandTest.java
@@ -10,7 +10,7 @@ import static educonnect.testutil.TypicalStudents.getTypicalAddressBook;
 import org.junit.jupiter.api.Test;
 
 import educonnect.logic.Messages;
-import educonnect.logic.parser.LinkCommandParser;
+import educonnect.model.AddressBook;
 import educonnect.model.Model;
 import educonnect.model.ModelManager;
 import educonnect.model.UserPrefs;
@@ -21,60 +21,59 @@ import educonnect.model.student.TelegramHandle;
 
 public class LinkCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private LinkCommandParser parser = new LinkCommandParser();
 
     @Test
     public void parse_validStudentId_success() {
         Student studentToLink = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
         StudentId studentId = studentToLink.getStudentId();
+
         LinkCommand.LinkStudentDescriptor linkStudentDescriptor = new LinkCommand.LinkStudentDescriptor();
-
-
         linkStudentDescriptor.setStudentId(studentId);
         LinkCommand linkCommand = new LinkCommand(linkStudentDescriptor);
         Student newStudent = createEditedStudent(studentToLink, linkStudentDescriptor);
+
         String expectedMessage = String.format(LinkCommand.MESSAGE_LINK_STUDENT_SUCCESS,
-                Messages.format(studentToLink));
+                Messages.format(newStudent));
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setStudent(studentToLink, newStudent);
 
-        model.setStudent(studentToLink, newStudent);
-
-        assertCommandSuccess(linkCommand, model, expectedMessage, model);
+        assertCommandSuccess(linkCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void parse_validEmail_success() {
         Student studentToLink = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
         Email email = studentToLink.getEmail();
+
         LinkCommand.LinkStudentDescriptor linkStudentDescriptor = new LinkCommand.LinkStudentDescriptor();
-
-
         linkStudentDescriptor.setEmail(email);
         LinkCommand linkCommand = new LinkCommand(linkStudentDescriptor);
         Student newStudent = createEditedStudent(studentToLink, linkStudentDescriptor);
+
         String expectedMessage = String.format(LinkCommand.MESSAGE_LINK_STUDENT_SUCCESS,
-                Messages.format(studentToLink));
+                Messages.format(newStudent));
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setStudent(studentToLink, newStudent);
 
-        model.setStudent(studentToLink, newStudent);
-
-        assertCommandSuccess(linkCommand, model, expectedMessage, model);
+        assertCommandSuccess(linkCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void parse_validTelegramHandle_success() {
         Student studentToLink = model.getFilteredStudentList().get(INDEX_FIRST_STUDENT.getZeroBased());
         TelegramHandle handle = studentToLink.getTelegramHandle();
+
         LinkCommand.LinkStudentDescriptor linkStudentDescriptor = new LinkCommand.LinkStudentDescriptor();
-
-
         linkStudentDescriptor.setTelegramHandle(handle);
         LinkCommand linkCommand = new LinkCommand(linkStudentDescriptor);
         Student newStudent = createEditedStudent(studentToLink, linkStudentDescriptor);
+
         String expectedMessage = String.format(LinkCommand.MESSAGE_LINK_STUDENT_SUCCESS,
-                Messages.format(studentToLink));
+                Messages.format(newStudent));
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setStudent(studentToLink, newStudent);
 
-        model.setStudent(studentToLink, newStudent);
-
-        assertCommandSuccess(linkCommand, model, expectedMessage, model);
+        assertCommandSuccess(linkCommand, model, expectedMessage, expectedModel);
     }
 
 

--- a/src/test/java/educonnect/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/educonnect/logic/parser/AddCommandParserTest.java
@@ -66,7 +66,7 @@ public class AddCommandParserTest {
         Student expectedStudent = new StudentBuilder(BOB)
                 .withTags(VALID_TAG_FRIEND)
                 .withTimetable(VALID_TIMETABLE_1)
-                .build();
+                .buildNoLink();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + STUDENT_ID_DESC_BOB + EMAIL_DESC_BOB
@@ -76,7 +76,7 @@ public class AddCommandParserTest {
 
         // multiple tags - all accepted
         Student expectedStudentMultipleTags = new StudentBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
-                .build();
+                .buildNoLink();
         assertParseSuccess(parser,
                 NAME_DESC_BOB + STUDENT_ID_DESC_BOB + EMAIL_DESC_BOB
                 + TELEGRAM_HANDLE_DESC_BOB + TAG_DESC_HUSBAND
@@ -84,7 +84,8 @@ public class AddCommandParserTest {
                 new AddCommand(expectedStudentMultipleTags));
 
         // no timetable in command, defaults to empty timetable
-        Student expectedStudentWithNoTimetable = new StudentBuilder(AMY).withTimetable(DEFAULT_EMPTY_TIMETABLE).build();
+        Student expectedStudentWithNoTimetable = new StudentBuilder(AMY)
+                .withTimetable(DEFAULT_EMPTY_TIMETABLE).buildNoLink();
         assertParseSuccess(parser,
                 NAME_DESC_AMY + STUDENT_ID_DESC_AMY + EMAIL_DESC_AMY
                 + TELEGRAM_HANDLE_DESC_AMY + TAG_DESC_FRIEND,
@@ -164,7 +165,7 @@ public class AddCommandParserTest {
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
-        Student expectedStudent = new StudentBuilder(AMY).withTags().build();
+        Student expectedStudent = new StudentBuilder(AMY).withTags().buildNoLink();
         assertParseSuccess(parser, NAME_DESC_AMY + STUDENT_ID_DESC_AMY + EMAIL_DESC_AMY + TELEGRAM_HANDLE_DESC_AMY,
                 new AddCommand(expectedStudent));
     }

--- a/src/test/java/educonnect/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/educonnect/logic/parser/AddressBookParserTest.java
@@ -37,7 +37,7 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_add() throws Exception {
-        Student student = new StudentBuilder().build();
+        Student student = new StudentBuilder().buildNoLink();
         AddCommand command = (AddCommand) parser.parseCommand(StudentUtil.getAddCommand(student));
         assertEquals(new AddCommand(student), command);
     }

--- a/src/test/java/educonnect/logic/parser/LinkCommandParserTest.java
+++ b/src/test/java/educonnect/logic/parser/LinkCommandParserTest.java
@@ -24,7 +24,7 @@ public class LinkCommandParserTest {
     private LinkCommandParser parser = new LinkCommandParser();
 
     @Test
-    public void parse_validArgsId_success() {
+    public void parse_validArgsStudentId_success() {
         LinkCommand.LinkStudentDescriptor linkStudentDescriptor = new LinkCommand.LinkStudentDescriptor();
         linkStudentDescriptor.setStudentId(new StudentId(VALID_STUDENT_ID_JOHN));
         linkStudentDescriptor.setLink(new Link(VALID_LINK_JOHN));
@@ -58,7 +58,6 @@ public class LinkCommandParserTest {
         LinkCommand.LinkStudentDescriptor linkStudentDescriptor = new LinkCommand.LinkStudentDescriptor();
         linkStudentDescriptor.setStudentId(new StudentId(VALID_STUDENT_ID_JOHN));
         linkStudentDescriptor.setLink(new Link(INVALID_LINK));
-        LinkCommand linkCommand = new LinkCommand(linkStudentDescriptor);
 
         CommandParserTestUtil.assertParseFailure(parser, " " + PREFIX_STUDENT_ID + VALID_STUDENT_ID_JOHN + " "
                 + PREFIX_LINK + INVALID_LINK, Link.MESSAGE_CONSTRAINTS);

--- a/src/test/java/educonnect/storage/JsonAdaptedStudentTest.java
+++ b/src/test/java/educonnect/storage/JsonAdaptedStudentTest.java
@@ -31,7 +31,7 @@ public class JsonAdaptedStudentTest {
     private static final String VALID_STUDENT_ID = BENSON.getStudentId().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_TELEGRAM_HANDLE = BENSON.getTelegramHandle().toString();
-    private static final String VALID_LINK = BENSON.getLink().toString();
+    private static final String VALID_LINK = BENSON.getLink().get().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());

--- a/src/test/java/educonnect/testutil/EditStudentDescriptorBuilder.java
+++ b/src/test/java/educonnect/testutil/EditStudentDescriptorBuilder.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 
 import educonnect.logic.commands.EditCommand.EditStudentDescriptor;
 import educonnect.model.student.Email;
+import educonnect.model.student.Link;
 import educonnect.model.student.Name;
 import educonnect.model.student.Student;
 import educonnect.model.student.StudentId;
@@ -38,7 +39,7 @@ public class EditStudentDescriptorBuilder {
         descriptor.setStudentId(student.getStudentId());
         descriptor.setEmail(student.getEmail());
         descriptor.setTelegramHandle(student.getTelegramHandle());
-        descriptor.setLink(student.getLink());
+        descriptor.setLink(student.getLink().orElse(null));
         descriptor.setTags(student.getTags());
         descriptor.setTimetable(student.getTimetable());
     }
@@ -72,6 +73,18 @@ public class EditStudentDescriptorBuilder {
      */
     public EditStudentDescriptorBuilder withTelegramHandle(String telegramHandle) {
         descriptor.setTelegramHandle(new TelegramHandle(telegramHandle));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Link} of the {@code EditStudentDescriptor} that we are building.
+     */
+    public EditStudentDescriptorBuilder withLink(String link) {
+        if (link == null) {
+            descriptor.setLink(null);
+        } else {
+            descriptor.setLink(new Link(link));
+        }
         return this;
     }
 

--- a/src/test/java/educonnect/testutil/StudentBuilder.java
+++ b/src/test/java/educonnect/testutil/StudentBuilder.java
@@ -1,6 +1,7 @@
 package educonnect.testutil;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import educonnect.model.student.Email;
@@ -29,15 +30,15 @@ public class StudentBuilder {
     public static final String ALTERNATE_EMAIL = "builderbob@gmail.com";
     public static final String ALTERNATE_TELEGRAM_HANDLE = "@bobthebuilder";
     public static final Timetable ALTERNATE_TIMETABLE = TypicalTimetableAndValues.VALID_TIMETABLE_1;
+    public static final String ALTERNATE_LINK = "https://www.youtube.com/";
 
-    public static final String ALTERNATIVE_LINK = "https://www.youtube.com/";
     private Name name;
     private StudentId studentId;
     private Email email;
     private TelegramHandle telegramHandle;
     private Set<Tag> tags;
     private Timetable timetable;
-    private Link link;
+    private Optional<Link> link;
 
     /**
      * Creates a {@code StudentBuilder} with the default details.
@@ -49,6 +50,7 @@ public class StudentBuilder {
         telegramHandle = new TelegramHandle(DEFAULT_TELEGRAM_HANDLE);
         tags = new HashSet<>();
         timetable = DEFAULT_TIMETABLE;
+        link = Optional.of(new Link(DEFAULT_LINK));
     }
 
 
@@ -75,7 +77,7 @@ public class StudentBuilder {
                 .withTelegramHandle(ALTERNATE_TELEGRAM_HANDLE)
                 .withEmail(ALTERNATE_EMAIL)
                 .withStudentId(ALTERNATE_STUDENT_ID)
-                .withLink(ALTERNATIVE_LINK)
+                .withLink(ALTERNATE_LINK)
                 .withTimetable(ALTERNATE_TIMETABLE);
     }
 
@@ -120,10 +122,10 @@ public class StudentBuilder {
     }
 
     /**
-     * Sets the {@code Email} of the {@code Student} that we are building.
+     * Sets the {@code Link} of the {@code Student} that we are building.
      */
     public StudentBuilder withLink(String l) {
-        this.link = new Link(l);
+        this.link = Optional.of(new Link(l));
         return this;
     }
 
@@ -138,7 +140,9 @@ public class StudentBuilder {
     public Student build() {
         return new Student(name, studentId, email, telegramHandle, link, tags, timetable);
     }
+
     public Student buildNoLink() {
-        return new Student(name, studentId, email, telegramHandle, tags, timetable); }
+        return new Student(name, studentId, email, telegramHandle, tags, timetable);
+    }
 
 }

--- a/src/test/java/educonnect/testutil/TypicalStudents.java
+++ b/src/test/java/educonnect/testutil/TypicalStudents.java
@@ -2,6 +2,8 @@ package educonnect.testutil;
 
 import static educonnect.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static educonnect.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static educonnect.logic.commands.CommandTestUtil.VALID_LINK_AMY;
+import static educonnect.logic.commands.CommandTestUtil.VALID_LINK_BOB;
 import static educonnect.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static educonnect.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static educonnect.logic.commands.CommandTestUtil.VALID_STUDENT_ID_AMY;
@@ -43,7 +45,7 @@ public class TypicalStudents {
             .withStudentId("A9876543N")
             .withEmail("heinz@example.com")
             .withTelegramHandle("@wallstreet")
-            .withLink("https://en.wikipedia.org/wiki/LeBron_James")
+            .withLink("https://github.com/tanjiajiajun/tp")
             .withTimetable(VALID_TIMETABLE_1).build();
 
     public static final Student DANIEL = new StudentBuilder()
@@ -59,7 +61,7 @@ public class TypicalStudents {
             .withStudentId("A9482224Y")
             .withEmail("werner@example.com")
             .withTelegramHandle("@michegan")
-            .withLink("https://en.wikipedia.org/wiki/LeBron_James")
+            .withLink("https://github.com/tanjiajiajun/tp")
             .withTimetable(VALID_TIMETABLE_2).build();
 
     public static final Student FIONA = new StudentBuilder()
@@ -74,8 +76,7 @@ public class TypicalStudents {
             .withStudentId("A6482442L")
             .withEmail("anna@example.com")
             .withTelegramHandle("@georgie")
-            .withLink("https://en.wikipedia.org/wiki/LeBron_James")
-            .withTimetable(VALID_TIMETABLE_2).build();
+            .withTimetable(VALID_TIMETABLE_2).buildNoLink();
 
     // Manually added
     public static final Student HOON = new StudentBuilder()
@@ -99,6 +100,7 @@ public class TypicalStudents {
             .withStudentId(VALID_STUDENT_ID_AMY)
             .withEmail(VALID_EMAIL_AMY)
             .withTelegramHandle(VALID_TELEGRAM_HANDLE_AMY)
+            .withLink(VALID_LINK_AMY)
             .withTags(VALID_TAG_FRIEND).build();
 
     public static final Student BOB = new StudentBuilder()
@@ -106,7 +108,7 @@ public class TypicalStudents {
             .withStudentId(VALID_STUDENT_ID_BOB)
             .withEmail(VALID_EMAIL_BOB)
             .withTelegramHandle(VALID_TELEGRAM_HANDLE_BOB)
-            .withLink("https://en.wikipedia.org/wiki/LeBron_James")
+            .withLink(VALID_LINK_BOB)
             .withTags(VALID_TAG_FRIEND).build();
 
 


### PR DESCRIPTION
Fixes #93

* Fix missing addressbook.json `link` field causing the addressbook to be purged clean
* Changed all `.fxml` documents to run on `JavaFX 17` instead of `JavaFX 21`
* Refactored Student `Link` to `Optional<Link>`
  * Students without a Link will save their `.json` `link` field  as `"link" : null,`
* Fixed all test cases related to Student `Link`

