### PR TITLE
Update list command with option to list timetable

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -168,7 +168,7 @@ This section describes some noteworthy details on how certain features are imple
   before the end time of the next `Period`. E.g. for the case of `Period` of 12-14, `Period` of 14-16 is allowed,
   but `Period` of 13-15 is not.
 
-![StudentClassDiagram.png](diagrams%2FStudentClassDiagram.png)
+<puml src="diagrams/StudentClassDiagram.puml" width="450"/>
 
 #### Adding/Editing a Student's Timetable
 * The `Timetable` of the `Student` is specified during the `add` command, indicated with a `c/` prefix.
@@ -180,7 +180,7 @@ This section describes some noteworthy details on how certain features are imple
   * E.g. an accepted `String` is `"mon: 13-15, 15-17 tue: 12-14 thu: 12-18"`
 * Below shows the sequence diagram when <u>adding</u> a student.
 
-![AddSequenceDiagram.png](diagrams%2FAddSequenceDiagram.png)
+<puml src="diagrams/AddSequenceDiagram.puml" width="450"/>
 
 #### \[Proposed\] Finding a Common Slot
 
@@ -535,6 +535,13 @@ testers are expected to do more *exploratory* testing.
        Expected: The most recent window size and location is retained.
 
 1. _{ more test cases …​ }_
+
+### Listing all students
+1. Listing all students in the address book.
+    1. Test case: `list`<br>
+      Expected: All students showing without timetables.
+    1. Test case: `list timetable`<br>
+      Expected: All students showing with timetables appearing in student cards.
 
 ### Deleting a student
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -47,7 +47,7 @@ EduConnect is a **desktop app for managing student contacts, optimized for use v
 1. Type the command in the command box and press Enter to execute it. e.g. typing **`help`** and pressing Enter will open the help window.<br>
    Some example commands you can try:
 
-   * `list` : Lists all contacts.
+   * `list` : Lists all students.
 
    * `add n/John Doe s/A1234567X h/@john.doe e/johnd@example.com t/tutorial-1 t/high-ability` : Adds a contact named `John Doe` to the Address Book.
 
@@ -79,7 +79,7 @@ EduConnect is a **desktop app for managing student contacts, optimized for use v
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME s/STUDENT_ID`, `s/STUDENT_ID n/NAME` is also acceptable.
 
-* Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
+* Extraneous parameters for commands that do not take in parameters (i.e. `help`,`exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
@@ -120,9 +120,9 @@ Examples:
 
 ### Listing all students : `list`
 
-Shows a list of all students in the address book.
+Shows a list of all students in the address book with the option to show timetables.
 
-Format: `list`
+Format: `list [timetable]`
 
 ### Editing a student : `edit`
 
@@ -258,5 +258,5 @@ Action     | Format, Examples
 **Edit**   | `edit INDEX [n/NAME] [s/STUDENT_ID] [e/EMAIL] [h/TELEGRAM_HANDLE] [l/WEBLINK] [c/TIMETABLE] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com c/mon: 8-10, 10-12 tue: 11-13 thu: 12-15, 15-17`
 **Find**   | `find [n/NAME] [s/STUDENT_ID] [h/TELEGRAM_HANDLE] [t/TAG]…`<br> e.g., `find n/john t/tutorial-1`
 **Link**   | `link [s/STUDENT_ID] [e/EMAIL] [h/TELEGRAM_HANDLE] l/WEBLINK` <br> e.g. `link s/A1654327X l/https://nus-cs2103-ay2324s2.github.io/website/`
-**List**   | `list`
+**List**   | `list`<br> `list timetable`
 **Help**   | `help`

--- a/src/main/java/educonnect/logic/commands/CommandResult.java
+++ b/src/main/java/educonnect/logic/commands/CommandResult.java
@@ -19,13 +19,17 @@ public class CommandResult {
     /** The application should exit. */
     private final boolean exit;
 
+    /** The application should show timetable of individual student. */
+    private final boolean showTimetable;
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean showTimetable) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
+        this.showTimetable = showTimetable;
     }
 
     /**
@@ -33,7 +37,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false);
+        this(feedbackToUser, false, false, false);
     }
 
     public String getFeedbackToUser() {
@@ -46,6 +50,10 @@ public class CommandResult {
 
     public boolean isExit() {
         return exit;
+    }
+
+    public boolean isShowTimetable() {
+        return showTimetable;
     }
 
     @Override
@@ -62,12 +70,13 @@ public class CommandResult {
         CommandResult otherCommandResult = (CommandResult) other;
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit;
+                && exit == otherCommandResult.exit
+                && showTimetable == otherCommandResult.showTimetable;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit);
+        return Objects.hash(feedbackToUser, showHelp, exit, showTimetable);
     }
 
     @Override
@@ -76,6 +85,7 @@ public class CommandResult {
                 .add("feedbackToUser", feedbackToUser)
                 .add("showHelp", showHelp)
                 .add("exit", exit)
+                .add("showTimetable", showTimetable)
                 .toString();
     }
 

--- a/src/main/java/educonnect/logic/commands/ExitCommand.java
+++ b/src/main/java/educonnect/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false);
     }
 
 }

--- a/src/main/java/educonnect/logic/commands/HelpCommand.java
+++ b/src/main/java/educonnect/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
     }
 }

--- a/src/main/java/educonnect/logic/commands/ListCommand.java
+++ b/src/main/java/educonnect/logic/commands/ListCommand.java
@@ -11,13 +11,27 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Shows a list of all students in the address book.\n"
+            + "Optional to list all students with their timetables\n"
+            + "Example 1: list\nExample 2: list timetable\n";
     public static final String MESSAGE_SUCCESS = "Listed all students";
 
+    public static final String MESSAGE_SUCCESS_TIMETABLE = "Listed all students with timetables";
 
+    private boolean showTimetable;
+
+    public ListCommand() {
+        this.showTimetable = false;
+    }
+    public ListCommand(boolean showTimeTable) {
+        this.showTimetable = showTimeTable;
+    }
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+        String outputMessage = showTimetable ? MESSAGE_SUCCESS_TIMETABLE : MESSAGE_SUCCESS;
         model.updateFilteredStudentList(Model.PREDICATE_SHOW_ALL_STUDENTS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(outputMessage, false, false, showTimetable);
     }
 }

--- a/src/main/java/educonnect/logic/parser/AddressBookParser.java
+++ b/src/main/java/educonnect/logic/parser/AddressBookParser.java
@@ -70,7 +70,7 @@ public class AddressBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/educonnect/logic/parser/ListCommandParser.java
+++ b/src/main/java/educonnect/logic/parser/ListCommandParser.java
@@ -1,0 +1,28 @@
+package educonnect.logic.parser;
+
+import static educonnect.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import educonnect.logic.commands.ListCommand;
+import educonnect.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ListCommand object
+ */
+public class ListCommandParser implements Parser<ListCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListCommand
+     * and returns an ListCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListCommand parse(String args) throws ParseException {
+        args = args.trim();
+        if (args.isEmpty()) {
+            return new ListCommand();
+        } else if (args.equals("timetable")) {
+            return new ListCommand(true);
+        } else {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/main/java/educonnect/ui/MainWindow.java
+++ b/src/main/java/educonnect/ui/MainWindow.java
@@ -163,6 +163,18 @@ public class MainWindow extends UiPart<Stage> {
         primaryStage.hide();
     }
 
+    /**
+     * Displays student timetable based on user list command.
+     */
+    @FXML
+    public void handleShowTimetable(boolean showTimetable) {
+        logger.info("User chooses to show timetables of students: " + showTimetable);
+        if (showTimetable) {
+            studentListPanel.showTimetable();
+        } else {
+            studentListPanel.hideTimetable();
+        }
+    }
     public StudentListPanel getStudentListPanel() {
         return studentListPanel;
     }
@@ -185,7 +197,7 @@ public class MainWindow extends UiPart<Stage> {
             if (commandResult.isExit()) {
                 handleExit();
             }
-
+            handleShowTimetable(commandResult.isShowTimetable());
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("An error occurred while executing command: " + commandText);

--- a/src/main/java/educonnect/ui/StudentCard.java
+++ b/src/main/java/educonnect/ui/StudentCard.java
@@ -55,7 +55,7 @@ public class StudentCard extends UiPart<Region> {
     /**
      * Creates a {@code StudentCard} with the given {@code Student} and index to display.
      */
-    public StudentCard(Student student, int displayedIndex) {
+    public StudentCard(Student student, int displayedIndex, boolean showTimetable) {
         super(FXML);
         this.student = student;
         id.setText(displayedIndex + ". ");
@@ -70,7 +70,8 @@ public class StudentCard extends UiPart<Region> {
         student.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
-        timetable.setText(student.getTimetable().toString());
+        String timetableStr = showTimetable ? student.getTimetable().toString() : "";
+        timetable.setText(timetableStr);
     }
 
     @FXML

--- a/src/main/java/educonnect/ui/StudentListPanel.java
+++ b/src/main/java/educonnect/ui/StudentListPanel.java
@@ -16,16 +16,22 @@ import javafx.scene.layout.Region;
 public class StudentListPanel extends UiPart<Region> {
     private static final String FXML = "StudentListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(StudentListPanel.class);
-
     @FXML
     private ListView<Student> studentListView;
-
     /**
-     * Creates a {@code StudentListPanel} with the given {@code ObservableList}.
+     * Creates a {@code StudentListPanel} with the given {@code ObservableList},
+     * and the default value of {@code showTimetable} option.
      */
     public StudentListPanel(ObservableList<Student> studentList) {
         super(FXML);
         studentListView.setItems(studentList);
+        studentListView.setCellFactory(listView -> new StudentListViewCell());
+    }
+    public void showTimetable() {
+        studentListView.setCellFactory(listView -> new StudentListViewCell(true));
+    }
+
+    public void hideTimetable() {
         studentListView.setCellFactory(listView -> new StudentListViewCell());
     }
 
@@ -33,6 +39,14 @@ public class StudentListPanel extends UiPart<Region> {
      * Custom {@code ListCell} that displays the graphics of a {@code Student} using a {@code StudentCard}.
      */
     class StudentListViewCell extends ListCell<Student> {
+        private boolean showTimetable;
+
+        public StudentListViewCell() {
+            this.showTimetable = false;
+        }
+        public StudentListViewCell(boolean showTimetable) {
+            this.showTimetable = showTimetable;
+        }
         @Override
         protected void updateItem(Student student, boolean empty) {
             super.updateItem(student, empty);
@@ -41,7 +55,7 @@ public class StudentListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new StudentCard(student, getIndex() + 1).getRoot());
+                setGraphic(new StudentCard(student, getIndex() + 1, showTimetable).getRoot());
             }
         }
     }

--- a/src/test/java/educonnect/logic/commands/CommandResultTest.java
+++ b/src/test/java/educonnect/logic/commands/CommandResultTest.java
@@ -14,7 +14,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -29,10 +29,13 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false)));
+
+        // different showTimetable value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, true)));
     }
 
     @Test
@@ -46,10 +49,13 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false).hashCode());
+
+        // different showTimetable value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, true).hashCode());
     }
 
     @Test
@@ -57,7 +63,7 @@ public class CommandResultTest {
         CommandResult commandResult = new CommandResult("feedback");
         String expected = CommandResult.class.getCanonicalName() + "{feedbackToUser="
                 + commandResult.getFeedbackToUser() + ", showHelp=" + commandResult.isShowHelp()
-                + ", exit=" + commandResult.isExit() + "}";
+                + ", exit=" + commandResult.isExit() + ", showTimetable=" + commandResult.isShowTimetable() + "}";
         assertEquals(expected, commandResult.toString());
     }
 }

--- a/src/test/java/educonnect/logic/commands/ExitCommandTest.java
+++ b/src/test/java/educonnect/logic/commands/ExitCommandTest.java
@@ -14,7 +14,7 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/educonnect/logic/commands/HelpCommandTest.java
+++ b/src/test/java/educonnect/logic/commands/HelpCommandTest.java
@@ -14,7 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/educonnect/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/educonnect/logic/parser/AddressBookParserTest.java
@@ -89,9 +89,14 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_list() throws Exception {
+    public void parseCommand_list_success() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_list_throwsParseException() {
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE), ()
+                -> parser.parseCommand(ListCommand.COMMAND_WORD + " 3"));
     }
 
     @Test


### PR DESCRIPTION
Resolves #110 
Fixes #118 

- Set default display to list without timetable
- User has option to list all students with timetables using `list timetable`
- Add list command parser for invalid command format
- Update corresponding User Guide section

## When application starts
<img width="945" alt="image" src="https://github.com/AY2324S2-CS2103-T14-1/tp/assets/103088135/b2aee927-da63-49f1-9c7b-f16b9f5a12f6">

## After user inputs`list timetable`
<img width="945" alt="image" src="https://github.com/AY2324S2-CS2103-T14-1/tp/assets/103088135/dd1a8104-9558-4b73-bb20-7d85ca28e4de">

## When list command followed by invalid words
<img width="945" alt="image" src="https://github.com/AY2324S2-CS2103-T14-1/tp/assets/103088135/8c847016-9ea7-40c4-bb6b-e37153fa3b40">
