### PR TITLE
Edit unique identifiers matches exactly with keyword

### DIFF
--- a/src/main/java/educonnect/logic/commands/EditCommand.java
+++ b/src/main/java/educonnect/logic/commands/EditCommand.java
@@ -112,6 +112,7 @@ public class EditCommand extends Command {
             model.updateFilteredStudentList(predicates);
         }
         List<Student> lastShownList = model.getFilteredStudentList();
+        assert lastShownList.size() <= 1; // unique identifier should only show 0/1 contact
         // no student matches the unique identifier
         if (lastShownList.isEmpty()) {
             throw new CommandException(MESSAGE_NO_STUDENT_FOUND);

--- a/src/main/java/educonnect/logic/parser/EditCommandParser.java
+++ b/src/main/java/educonnect/logic/parser/EditCommandParser.java
@@ -34,9 +34,9 @@ import educonnect.logic.commands.EditCommand;
 import educonnect.logic.parser.exceptions.ParseException;
 import educonnect.model.student.Student;
 import educonnect.model.student.Tag;
-import educonnect.model.student.predicates.EmailContainsKeywordsPredicate;
-import educonnect.model.student.predicates.IdContainsKeywordsPredicate;
-import educonnect.model.student.predicates.TelegramContainsKeywordsPredicate;
+import educonnect.model.student.predicates.EmailMatchesKeywordsPredicate;
+import educonnect.model.student.predicates.IdMatchesKeywordsPredicate;
+import educonnect.model.student.predicates.TelegramMatchesKeywordsPredicate;
 import educonnect.model.student.timetable.Timetable;
 
 /**
@@ -83,13 +83,13 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         List<Predicate<Student>> predicates = new ArrayList<>();
         identifierArgMultimap.getValue(EDIT_ID_PREFIX_EMAIL).ifPresent(keywordEmail ->
-            predicates.add(new EmailContainsKeywordsPredicate(keywordEmail))
+            predicates.add(new EmailMatchesKeywordsPredicate(keywordEmail))
         );
         identifierArgMultimap.getValue(EDIT_ID_PREFIX_STUDENT_ID).ifPresent(keywordId ->
-            predicates.add(new IdContainsKeywordsPredicate(keywordId))
+            predicates.add(new IdMatchesKeywordsPredicate(keywordId))
         );
         identifierArgMultimap.getValue(EDIT_ID_PREFIX_TELEGRAM_HANDLE).ifPresent(keywordTeleHandle ->
-            predicates.add(new TelegramContainsKeywordsPredicate(keywordTeleHandle))
+            predicates.add(new TelegramMatchesKeywordsPredicate(keywordTeleHandle))
         );
         Index index;
         try {

--- a/src/main/java/educonnect/model/student/predicates/EmailMatchesKeywordsPredicate.java
+++ b/src/main/java/educonnect/model/student/predicates/EmailMatchesKeywordsPredicate.java
@@ -1,9 +1,9 @@
 package educonnect.model.student.predicates;
 
+import java.util.function.Predicate;
+
 import educonnect.commons.util.ToStringBuilder;
 import educonnect.model.student.Student;
-
-import java.util.function.Predicate;
 
 /**
  * Tests that a {@code Student}'s {@code Email} matches exactly the keywords given.

--- a/src/main/java/educonnect/model/student/predicates/EmailMatchesKeywordsPredicate.java
+++ b/src/main/java/educonnect/model/student/predicates/EmailMatchesKeywordsPredicate.java
@@ -1,0 +1,42 @@
+package educonnect.model.student.predicates;
+
+import educonnect.commons.util.ToStringBuilder;
+import educonnect.model.student.Student;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Student}'s {@code Email} matches exactly the keywords given.
+ */
+public class EmailMatchesKeywordsPredicate implements Predicate<Student> {
+    private final String keywordEmail;
+
+    public EmailMatchesKeywordsPredicate(String keywordEmail) {
+        this.keywordEmail = keywordEmail; //replace
+    }
+
+    @Override
+    public boolean test(Student student) {
+        return student.getEmail().toString().equals(keywordEmail);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EmailMatchesKeywordsPredicate)) {
+            return false;
+        }
+
+        EmailMatchesKeywordsPredicate otherEmailMatchesKeywordsPredicate = (EmailMatchesKeywordsPredicate) other;
+        return keywordEmail.equals(otherEmailMatchesKeywordsPredicate.keywordEmail);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywordEmail).toString();
+    }
+}

--- a/src/main/java/educonnect/model/student/predicates/IdMatchesKeywordsPredicate.java
+++ b/src/main/java/educonnect/model/student/predicates/IdMatchesKeywordsPredicate.java
@@ -1,0 +1,42 @@
+package educonnect.model.student.predicates;
+
+import java.util.function.Predicate;
+
+import educonnect.commons.util.ToStringBuilder;
+import educonnect.model.student.Student;
+
+/**
+ * Tests that a {@code Student}'s {@code Id} matches exactly the keywords given.
+ */
+public class IdMatchesKeywordsPredicate implements Predicate<Student> {
+    private final String keywordId;
+
+    public IdMatchesKeywordsPredicate(String keywordId) {
+        this.keywordId = keywordId; //replace
+    }
+
+    @Override
+    public boolean test(Student student) {
+        return student.getStudentId().toString().equals(keywordId);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof IdMatchesKeywordsPredicate)) {
+            return false;
+        }
+
+        IdMatchesKeywordsPredicate otherIdMatchesKeywordsPredicate = (IdMatchesKeywordsPredicate) other;
+        return keywordId.equals(otherIdMatchesKeywordsPredicate.keywordId);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywordId).toString();
+    }
+}

--- a/src/main/java/educonnect/model/student/predicates/TelegramMatchesKeywordsPredicate.java
+++ b/src/main/java/educonnect/model/student/predicates/TelegramMatchesKeywordsPredicate.java
@@ -1,0 +1,43 @@
+package educonnect.model.student.predicates;
+
+import java.util.function.Predicate;
+
+import educonnect.commons.util.ToStringBuilder;
+import educonnect.model.student.Student;
+
+/**
+ * Tests that a {@code Student}'s {@code Email} matches any of the keywords given.
+ */
+public class TelegramMatchesKeywordsPredicate implements Predicate<Student> {
+    private final String keywordTelegram;
+
+    public TelegramMatchesKeywordsPredicate(String keywordTelegram) {
+        this.keywordTelegram = keywordTelegram; //replace
+    }
+
+    @Override
+    public boolean test(Student student) {
+        return student.getTelegramHandle().toString().equals(keywordTelegram);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof TelegramMatchesKeywordsPredicate)) {
+            return false;
+        }
+
+        TelegramMatchesKeywordsPredicate otherTelegramMatchesKeywordsPredicate =
+                (TelegramMatchesKeywordsPredicate) other;
+        return keywordTelegram.equals(otherTelegramMatchesKeywordsPredicate.keywordTelegram);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywordTelegram).toString();
+    }
+}


### PR DESCRIPTION
Resolves #180 
- Add predicates for exact matching for unique identifiers (telegram handle, student id, and email)
- Update edit command for the unique identifiers logic to match exactly the given keyword