### PR TITLE
Remove redundant descriptions and fix tip box bug

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -621,7 +621,7 @@ finding common slots and copying student emails, which showcases our goal of cre
 
 - Adherence to project timelines and deliver the milestones on time.
 
-## **Appendix D: Planner Enhancements**
+## **Appendix D: Planned Enhancements**
 
 Team Size: 6
 1. **Use a better font:** User experience is greatly influenced by font, and choosing the right font can significantly enhance readability, Especially for EduConnect with numeric details of students displayed, the current font causes confusion sometimes. TWe plan to adapt a new font which not only improve the overall appearance of the platform but also contribute to a smoother reading experience for users.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -153,7 +153,7 @@ EduConnect is a **desktop app for managing student contacts, optimized for use v
 
 * By default, timetables of students are not shown.
 
-* To show or hide timetables of students, use `list` command. The choice will be saved and timetables will remain visible/invisible for subsequent command results.
+* To show or hide timetables of students, use `list` command.
 
 ### Viewing help: `help`
 
@@ -200,9 +200,9 @@ Format: `list [timetable]`
 
 <box type="tip" seamless>
 
-**Tip:** By default, timetables of students are not shown.
+**Tip:** The choice of show timetables option will be saved and timetables will remain visible/invisible for subsequent command results. However, the choice will be restored to hiding timetable each time application is relaunched.
 
-**Tip:** To show or hide timetables of students, use `list` command. The choice will be saved and timetables will remain visible/invisible for subsequent command results. However, the choice will be restored to hiding timetable each time application is relaunched.
+</box>
 
 Examples:
 * `list`


### PR DESCRIPTION
- The notes for displaying timetable under `Features` section has some overlapping information with `list` command descriptions
- Separate the info such that displaying timetable is mentioned in `Features` section, and preference saving(which is operated by the command) is mentioned in `list` section